### PR TITLE
uses buildin buttons for users without keypad

### DIFF
--- a/LNPoS.ino
+++ b/LNPoS.ino
@@ -9,6 +9,8 @@
 
 #include "logo.c"
 
+// flag to enable keypad -- comment to use the build in buttons
+#define KEYPAD
 #define KEYBOARD_I2C_ADDR     0X08
 #define KEYBOARD_INT          5
 
@@ -63,9 +65,14 @@ void loop()
 {
   input_screen();
   cntr = "1";
+#ifndef KEYPAD
+  temp = 0.01;
+#endif
   while (cntr == "1"){
     M5.update();
+#ifdef KEYPAD
     get_keypad(); 
+#endif
     if (M5.BtnC.wasReleased()) {
       processing_screen();
       getinvoice(nosats);
@@ -78,6 +85,7 @@ void loop()
       inputs = "";
     }
     else if (M5.BtnB.wasReleased()) {
+#ifdef KEYPAD
       processing_screen();
       nosats = "0";
       getinvoice(nosats);
@@ -88,6 +96,9 @@ void loop()
       M5.Lcd.fillScreen(BLACK);
       key_val = "";
       inputs = "";
+#else
+	  temp *= 1.1;
+#endif
     }
     else if (M5.BtnA.wasReleased()) {
       M5.Lcd.fillScreen(BLACK);
@@ -97,10 +108,15 @@ void loop()
       key_val = "";
       inputs = "";  
       nosats = "";
+#ifndef KEYPAD
+      temp = 1;
+#endif
     }
+#ifdef KEYPAD
     inputs += key_val;
     temp = inputs.toInt();
     temp = temp / 100;
+#endif
     fiat = temp;
     satoshis = temp/conversion;
     int intsats = (int) round(satoshis*100000000.0);
@@ -125,7 +141,11 @@ void input_screen()
   M5.Lcd.setTextColor(TFT_WHITE);
   M5.Lcd.setTextSize(3);
   M5.Lcd.setCursor(0, 40);
+#ifdef KEYPAD
   M5.Lcd.println("Amount then C");
+#else
+  M5.Lcd.println("");
+#endif
   M5.Lcd.println("");
   M5.Lcd.println(String(currency) + ": ");
   M5.Lcd.println("");
@@ -133,8 +153,13 @@ void input_screen()
   M5.Lcd.println("");
   M5.Lcd.println("");
   M5.Lcd.setTextSize(2);
+#ifdef KEYPAD
   M5.Lcd.setCursor(50, 200);
   M5.Lcd.println("TO RESET PRESS A");
+#else
+  M5.Lcd.setCursor(40, 220);
+  M5.Lcd.println("RESET   +10%     OK");
+#endif
 }
 
 void processing_screen()


### PR DESCRIPTION
As I don't have the keypad and wanted to test the LNPoS without waiting for it, I have programmed the m5stack buildin button B to increase the amount by +10%.

This might be useful for other developers and even for restaurants that are ok with setting approximate price (as 10% tips are usual in many places).
    
It also introduces some improvements in the UI by showing what each of the buttons does just above it (instead of calling them by names A,B and C).
    
Reset set the price to 1, while restarting the device sets the price to 0.01 for testing.

To use the LNPoS without the KEYPAD, comment the #define KEYPAD flag on line 13.