### PR TITLE
fix block explorer link

### DIFF
--- a/bitcoinPoSBareBones/bitcoinPoSBareBones.ino
+++ b/bitcoinPoSBareBones/bitcoinPoSBareBones.ino
@@ -521,7 +521,7 @@ void onchainMain()
         {
           while (unConfirmed)
           {
-            qrData = "https:/" + lnurlATMMS + "/address/" + qrData;
+            qrData = "https://" + lnurlATMMS + "/address/" + qrData;
             qrShowCodeOnchain(false, " *MENU");
             while (unConfirmed)
             {

--- a/bitcoinPoSM5Stack/bitcoinPoSM5Stack.ino
+++ b/bitcoinPoSM5Stack/bitcoinPoSM5Stack.ino
@@ -520,7 +520,7 @@ void onchainMain()
         {
           while (unConfirmed)
           {
-            qrData = "https:/" + lnurlATMMS + "/address/" + qrData;
+            qrData = "https://" + lnurlATMMS + "/address/" + qrData;
             qrShowCodeOnchain(false, "   MENU");
             while (unConfirmed)
             {

--- a/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
+++ b/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
@@ -522,7 +522,7 @@ void onchainMain()
         {
           while (unConfirmed)
           {
-            qrData = "https:/" + lnurlATMMS + "/address/" + qrData;
+            qrData = "https://" + lnurlATMMS + "/address/" + qrData;
             qrShowCodeOnchain(false, " *MENU");
             while (unConfirmed)
             {


### PR DESCRIPTION
Fixes the issue that currently the mempool.space link is given in the QR as
```
https:/mempool.space/address/bc1...
```
Changed to  `https://` in all 3 .ino-s.


(Previously could give the custom link as `/mempool.space` to work around this)