### PR TITLE
speeds up payment detection

### DIFF
--- a/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
+++ b/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
@@ -571,7 +571,7 @@ void lnMain()
           timer = 5000;
           delay(3000);
         }
-        while (timer < 4000)
+        while (timer < 3000)
         {
           key_val = "";
           getKeypad(false, true, false, false);
@@ -583,7 +583,7 @@ void lnMain()
             unConfirmed = false;
             timer = 5000;
           }
-          delay(200);
+          delay(100);
           timer = timer + 100;
         }
       }


### PR DESCRIPTION
Before this change it took over 12 seconds between invoice checks, which I find way to long for LN stuff.