### PR TITLE
removes basic auth on POS config page

### DIFF
--- a/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
+++ b/bitcoinPoSTdisplay/bitcoinPoSTdisplay.ino
@@ -359,8 +359,8 @@ void setup()
     return String();
   });
 
-  config.auth = AC_AUTH_BASIC;
-  config.authScope = AC_AUTHSCOPE_AUX;
+  //config.auth = AC_AUTH_BASIC;
+  //config.authScope = AC_AUTHSCOPE_AUX;
   config.ticker = true;
   config.autoReconnect = true;
   config.apid = "bitcoinPoS-" + String((uint32_t)ESP.getEfuseMac(), HEX);


### PR DESCRIPTION
I couldn't find the username/password needed for logging into the POS config page. This removes the auth request. Alternative would be to set a username/password according to https://hieromon.github.io/AutoConnect/adauthentication.html#__code_1