### PR TITLE
Fix menu selection logic, remove compiler warnings, improve keypad responsiveness

### DIFF
--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -518,7 +518,7 @@ void onchainMain()
     {
       HDPublicKey hd(masterKey);
       qrData = hd.derive(String("m/0/") + addressNo).address();
-      qrShowCodeOnchain(true, " *MENU #CHECK");
+      qrShowCodeOnchain(true, " *MENU        #CHECK");
 
       while (unConfirmed)
       {
@@ -669,7 +669,7 @@ void lnurlPoSMain()
     else if (key_val == "#")
     {
       makeLNURL();
-      qrShowCodeLNURL(" *MENU #SHOW PIN");
+      qrShowCodeLNURL(" *MENU     #SHOW PIN");
 
       while (unConfirmed)
       {
@@ -835,7 +835,7 @@ void isLNMoneyNumber(bool cleared)
   tft.println("SAT: ");
   tft.setCursor(0, 120);
   tft.setTextSize(2);
-  tft.println(" *MENU #INVOICE");
+  tft.println(" *MENU       #INVOICE");
 
   if (!cleared)
   {
@@ -870,7 +870,7 @@ void isLNURLMoneyNumber(bool cleared)
   tft.println(String(currencyPoS) + ": ");
   tft.setCursor(0, 120);
   tft.setTextSize(2);
-  tft.println(" *MENU #INVOICE");
+  tft.println(" *MENU     #INVOICE");
   tft.setTextSize(3);
 
   if (!cleared)
@@ -900,7 +900,7 @@ void isATMMoneyNumber(bool cleared)
   tft.println(String(currencyATM) + ": ");
   tft.setCursor(0, 120);
   tft.setTextSize(2);
-  tft.println(" *MENU #WITHDRAW");
+  tft.println(" *MENU     #WITHDRAW");
   tft.setTextSize(3);
 
   if (!cleared)
@@ -930,7 +930,7 @@ void isATMMoneyPin(bool cleared)
   tft.println("PIN:");
   tft.setCursor(0, 120);
   tft.setTextSize(2);
-  tft.println(" *MENU #CLEAR");
+  tft.println(" *MENU        #CLEAR");
 
   pinToShow = dataIn;
   tft.setTextSize(3);
@@ -955,7 +955,7 @@ void inputScreenOnChain()
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   tft.setTextSize(2);
   tft.setCursor(0, 120);
-  tft.println(" *MENU #ADDRESS");
+  tft.println(" *MENU      #ADDRESS");
 }
 
 void qrShowCodeln()
@@ -1154,50 +1154,6 @@ void logo()
   tft.print("Powered by LNbits");
 }
 
-long int lastBatteryCheck = 0;
-void updateBatteryStatus(bool force = false)
-{
-  // throttle
-  if(!force && lastBatteryCheck != 0 && millis() - lastBatteryCheck < 5000) {
-    return;
-  }
-
-  lastBatteryCheck = millis();
-
-  // update
-  const int batteryPercentage = getBatteryPercentage();
-
-  String batteryPercentageText = "";
-  if (batteryPercentage == USB_POWER) {
-    tft.setTextColor(TFT_GREEN, TFT_BLACK);
-    batteryPercentageText = " USB";
-
-  } else {
-    if(batteryPercentage >= 60) {
-      tft.setTextColor(TFT_GREEN, TFT_BLACK);
-
-    } else if (batteryPercentage >= 20) {
-      tft.setTextColor(TFT_YELLOW, TFT_BLACK);
-
-    } else {
-      tft.setTextColor(TFT_RED, TFT_BLACK);
-    }
-
-    if(batteryPercentage != 100) {
-      batteryPercentageText += " ";
-      
-      if (batteryPercentage < 10) {
-        batteryPercentageText += " ";
-      }
-    }
-
-    batteryPercentageText += String(batteryPercentage) + "%";
-  }
-
-  tft.setCursor(190, 120);
-  tft.print(batteryPercentageText);
-}
-
 void menuLoop()
 {
   Serial.println("menuLoop");
@@ -1211,9 +1167,7 @@ void menuLoop()
   tft.setCursor(0, 120);
   tft.setTextSize(2);
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
-  tft.print(" *NEXT #SELECT");
-
-  updateBatteryStatus(true);
+  tft.print(" *NEXT       #SELECT");
 
   // menu items
   selection = "";
@@ -1239,15 +1193,19 @@ void menuLoop()
         if (menuItems[i] == menuItems[menuItemNo])
         {
           tft.setTextColor(TFT_GREEN, TFT_BLACK);
+          tft.print("    > ");
+          tft.print(menuItems[i]);
+          tft.println(" <");
           selection = menuItems[i];
         }
         else
         {
           tft.setTextColor(TFT_WHITE, TFT_BLACK);
+          tft.print("      ");
+          tft.print(menuItems[i]);
+          tft.println("  ");
         }
 
-        tft.print("  ");
-        tft.println(menuItems[i]);
         menuItemCount++;
       }
     }
@@ -1275,7 +1233,6 @@ void menuLoop()
       }
       else
       {
-        updateBatteryStatus();
         delay(50);
       }
     }

--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -1053,7 +1053,7 @@ void qrShowCodeLNURL(String message)
     for (int8_t x = -1; x < qrcoded.size + 1; x++)
     {
       if(x < 0 || y < 0 || x >= qrcoded.size || y >= qrcoded.size)
-        tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE);
+        tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE); // could reduce contrast with TFT_LIGHTGREY
       else
       {
         if (qrcode_getModule(&qrcoded, x, y))
@@ -1062,7 +1062,7 @@ void qrShowCodeLNURL(String message)
         }
         else
         {
-          tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE);
+          tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE); // could reduce contrast with TFT_LIGHTGREY
         }
       }
     }

--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -1259,17 +1259,11 @@ void menuLoop()
 
       if (key_val == "*")
       {
-        menuItemNo++;
-        if (menuItemCheck[menuItemNo] < 1)
-        {
+        do {
           menuItemNo++;
+          menuItemNo %= sizeof(menuItems) / sizeof(menuItems[0]);
         }
-
-        if (menuItemNo > menuItemCount)
-        {
-          menuItemNo = 0;
-          break;
-        }
+        while(menuItemCheck[menuItemNo] == 0);
 
         btnloop = false;
       }

--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -1040,7 +1040,7 @@ void qrShowCodeOnchain(bool anAddress, String message)
 
 void qrShowCodeLNURL(String message)
 {
-  tft.fillScreen(TFT_WHITE);
+  tft.fillScreen(TFT_BLACK);
 
   qrData.toUpperCase();
   const char *qrDataChar = qrData.c_str();
@@ -1048,17 +1048,22 @@ void qrShowCodeLNURL(String message)
   uint8_t qrcodeData[qrcode_getBufferSize(20)];
   qrcode_initText(&qrcoded, qrcodeData, 6, 0, qrDataChar);
 
-  for (uint8_t y = 0; y < qrcoded.size; y++)
+  for (int8_t y = -1; y < (qrcoded.size + 1); y++)
   {
-    for (uint8_t x = 0; x < qrcoded.size; x++)
+    for (int8_t x = -1; x < qrcoded.size + 1; x++)
     {
-      if (qrcode_getModule(&qrcoded, x, y))
-      {
-        tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_BLACK);
-      }
+      if(x < 0 || y < 0 || x >= qrcoded.size || y >= qrcoded.size)
+        tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE);
       else
       {
-        tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE);
+        if (qrcode_getModule(&qrcoded, x, y))
+        {
+          tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_BLACK);
+        }
+        else
+        {
+          tft.fillRect(65 + 3 * x, 5 + 3 * y, 3, 3, TFT_WHITE);
+        }
       }
     }
   }

--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -19,6 +19,7 @@ fs::SPIFFSFS &FlashFS = SPIFFS;
 
 #define PARAM_FILE "/elements.json"
 #define KEY_FILE "/thekey.txt"
+#define USB_POWER 1000 // battery percentage sentinel value to indicate USB power
 
 // variables
 String inputs;
@@ -1166,7 +1167,7 @@ void updateBatteryStatus(bool force = false)
   const int batteryPercentage = getBatteryPercentage();
 
   String batteryPercentageText = "";
-  if (batteryPercentage == NULL) {
+  if (batteryPercentage == USB_POWER) {
     tft.setTextColor(TFT_GREEN, TFT_BLACK);
     batteryPercentageText = " USB";
 
@@ -1584,7 +1585,7 @@ unsigned int getBatteryPercentage()
 
   const int batteryPercentage = (int) (batteryCurVAboveMin / batteryAllowedRange * 100);
   if (batteryPercentage > 150) {
-    return NULL;
+    return USB_POWER;
   }
 
   return max(min(batteryPercentage, 100), 0);

--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -20,6 +20,7 @@ fs::SPIFFSFS &FlashFS = SPIFFS;
 #define PARAM_FILE "/elements.json"
 #define KEY_FILE "/thekey.txt"
 #define USB_POWER 1000 // battery percentage sentinel value to indicate USB power
+#define KEYPAD_DELAY 50 // millisecond delay between keypad reads
 
 // variables
 String inputs;
@@ -607,7 +608,7 @@ void lnMain()
               getKeypad(false, true, false, false);
 
               if (key_val != "*") {
-                delay(100);
+                delay(KEYPAD_DELAY);
               }
             }
           }
@@ -628,10 +629,10 @@ void lnMain()
             break;
             
           } else {
-            delay(100);
+            delay(KEYPAD_DELAY);
           }
 
-          timer = timer + 100;
+          timer = timer + KEYPAD_DELAY;
         }
 
         isFirstRun = false;
@@ -643,7 +644,7 @@ void lnMain()
     }
     else
     {
-      delay(100);
+      delay(KEYPAD_DELAY);
     }
   }
 }
@@ -698,7 +699,7 @@ void lnurlPoSMain()
     }
     else
     {
-      delay(100);
+      delay(KEYPAD_DELAY);
     }
   }
 }
@@ -767,7 +768,7 @@ void lnurlATMMain()
     }
     else
     {
-      delay(100);
+      delay(KEYPAD_DELAY);
     }
   }
 }
@@ -1275,7 +1276,7 @@ void menuLoop()
       else
       {
         updateBatteryStatus();
-        delay(100);
+        delay(50);
       }
     }
   }


### PR DESCRIPTION
Where LNURLPos & LNURLATM are the only menu items available, it's not currently possible to select LNURLATM.
An update to the logic for selecting the next item on a '*' key press fixes this.

There are two compiler warnings with regard to NULL values which are fixed here by introducing a sentinel value for USB_POWER.

The keypad delay is parameterised and reduced to 50ms.
This makes the keypad feel more responsive - no keybounce issues have been observed.