### PR TITLE
Fix typo: PAID instead of PAYED

### DIFF
--- a/lnPoSTdisplay/lnPoSTdisplay.ino
+++ b/lnPoSTdisplay/lnPoSTdisplay.ino
@@ -1103,7 +1103,7 @@ void paymentSuccess()
   tft.setTextColor(TFT_GREEN, TFT_BLACK);
   tft.setTextSize(3);
   tft.setCursor(70, 50);
-  tft.println("PAYED");
+  tft.println("PAID");
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   tft.setTextSize(2);
   tft.println("  PRESS * FOR MENU");


### PR DESCRIPTION
In the lnPoSTdisplay version, the payment success screen shows the
message PAYED. The correct English term would be PAID.

Change tested with TTGO device:

![image](https://user-images.githubusercontent.com/19550140/164908963-def0f679-1d0f-41b9-9bde-0ab3aad2eadc.png)
