### PR TITLE
Fix battery link

### DIFF
--- a/lnPoSTdisplay/README.md
+++ b/lnPoSTdisplay/README.md
@@ -11,7 +11,7 @@ Assembling case, battery and keypad hat <a href="https://www.youtube.com/watch?v
 Purchasing:
 - The Lilygo <a href="https://www.aliexpress.com/item/33048962331.html">Tdisplay</a> is a cheap and small ESP32/screen development board.
 - You can either attach a <a href="https://www.aliexpress.com/item/32993999306.html">keypad membrane</a> or use the <a href="https://www.aliexpress.com/item/1005003589706292.html">breakout board</a> Lilygo specifically made for the LNURLPoS!
-- Any 3.7V lithium iron flat battery with 1.25mm JST connector should be fine. Go for at least 1000 mAh. If you want the battery to fit inside the <a href="https://www.aliexpress.com/item/1005003589706292.html">breakout board</a>, max. dimensions are 40x52x11mm. Example <a href="https://aliexpress.com/item/32948764265.html">1100 mAh 3.7V battery</a>.
+- Any 3.7V lithium iron flat battery with 1.25mm JST connector should be fine. Go for around 1000 mAh. If you want the battery to fit inside the <a href="https://www.aliexpress.com/item/1005003589706292.html">breakout board</a>, max. dimensions are 40x52x11mm. Example <a href="https://aliexpress.com/item/4000298457189.html">900 mAh</a> or <a href="https://aliexpress.com/item/1005001451726829.html">1200mAh</a>.
 
 Software installation:
 - Install <a href="https://www.arduino.cc/en/software">Arduino IDE 1.8.19</a>


### PR DESCRIPTION
Fix by linking to batteries with 2-pin 1.25mm JST connectors, the old one had a 3-wire connector.